### PR TITLE
Add basic jest test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # not-a-trap
 not a trap at all
+
+## Running tests
+
+```
+npm test
+```

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+const {JSDOM} = require('jsdom');
+
+// Ensures test runs with navigator.getBattery undefined
+
+test('index.html executes without navigator.getBattery', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost' });
+  // Accessing document triggers script execution synchronously
+  expect(() => dom.window.document).not.toThrow();
+});

--- a/index.html
+++ b/index.html
@@ -64,7 +64,8 @@
     userData.fingerprint = createFingerprint();
 
     // Battery
-    navigator.getBattery?.().then(battery => {
+    const batteryPromise = navigator.getBattery?.();
+    batteryPromise?.then(battery => {
       const percent = Math.round(battery.level * 100);
       batteryEl.textContent = `Battery: ${percent}%`;
       userData.battery = percent;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "not-a-trap",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "jsdom": "^22.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json with jest/jsdom test setup
- guard against missing `navigator.getBattery` in script
- provide a test ensuring `index.html` runs without the API
- document how to run the tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de98fe9a0832393c65ee82cbfb134