### PR TITLE
Fix battery check for browsers without getBattery

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,11 +64,13 @@
     userData.fingerprint = createFingerprint();
 
     // Battery
-    navigator.getBattery?.().then(battery => {
-      const percent = Math.round(battery.level * 100);
-      batteryEl.textContent = `Battery: ${percent}%`;
-      userData.battery = percent;
-    });
+    if (navigator.getBattery) {
+      navigator.getBattery().then(battery => {
+        const percent = Math.round(battery.level * 100);
+        batteryEl.textContent = `Battery: ${percent}%`;
+        userData.battery = percent;
+      });
+    }
 
     nameInput.addEventListener("change", () => {
       const name = nameInput.value.trim();


### PR DESCRIPTION
## Summary
- ensure `.then` is only called if `navigator.getBattery` exists

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684de98e49d4832399eeefb0efcdaed3