### PR TITLE
Fix battery check

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -6,7 +6,14 @@ const {JSDOM} = require('jsdom');
 
 test('index.html executes without navigator.getBattery', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
-  const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost' });
+  const dom = new JSDOM(html, {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost',
+    beforeParse(window) {
+      delete window.navigator.getBattery;
+    }
+  });
   // Accessing document triggers script execution synchronously
   expect(() => dom.window.document).not.toThrow();
 });

--- a/index.html
+++ b/index.html
@@ -60,11 +60,13 @@
     userData.fingerprint = createFingerprint();
 
     // Battery
-navigator.getBattery?.().then(battery => {
-  const percent = Math.round(battery.level * 100);
-  batteryEl.textContent = `Battery: ${percent}%`;
-  userData.battery = percent;
-});
+    if (navigator.getBattery) {
+      navigator.getBattery().then(battery => {
+        const percent = Math.round(battery.level * 100);
+        batteryEl.textContent = `Battery: ${percent}%`;
+        userData.battery = percent;
+      });
+    }
 
     countdownEl.style.display = "block";
     logVisitor();


### PR DESCRIPTION
## Summary
- only run `navigator.getBattery` when it exists
- make Jest test explicitly remove `getBattery`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df6b0ab4c832395322d723cc4a3a7